### PR TITLE
Fix show only build configurations available for the solution in publish screen

### DIFF
--- a/src/CloudFoundry.VisualStudio/Forms/EditDialog.xaml.cs
+++ b/src/CloudFoundry.VisualStudio/Forms/EditDialog.xaml.cs
@@ -56,7 +56,7 @@ namespace CloudFoundry.VisualStudio
             if (this.currentProj != null && this.currentProj.ConfigurationManager != null)
             {
                 var configurations = this.currentProj.ConfigurationManager.ConfigurationRowNames as Array;
-                var platforms = this.currentProj.ConfigurationManager.SupportedPlatforms as Array;
+                var platforms = this.currentProj.ConfigurationManager.PlatformNames as Array;
 
                 if (configurations != null)
                 {


### PR DESCRIPTION
On the Publish screen, the configuration dropdown list shows build configurations that are not available for the solution. As a result, selecting one of those causes the build on the server will fail.
Steps to reproduce:
Create a solution with only "Any CPU" as build configuration. Publish it to CF with "build local" unchecked and select x86 as Build Configuration