### PR TITLE
Remove display of organization and space roles in Cloud Foundry Explorer

### DIFF
--- a/src/CloudFoundry.VisualStudio/Model/CloudFoundryTarget.cs
+++ b/src/CloudFoundry.VisualStudio/Model/CloudFoundryTarget.cs
@@ -85,15 +85,12 @@ namespace CloudFoundry.VisualStudio.Model
             PagedResponseCollection<ListAllOrganizationsResponse> orgs = await client.Organizations.ListAllOrganizations();
 
             JwtSecurityToken token = new JwtSecurityToken(authenticationContext.Token.AccessToken);
-            Guid userId = new Guid(token.Subject);
-
-            GetUserSummaryResponse userSummary = await client.Users.GetUserSummary(userId);
-
+            
             while (orgs != null && orgs.Properties.TotalResults != 0)
             {
                 foreach (var org in orgs)
                 {
-                    result.Add(new Organization(org, userSummary, client));
+                    result.Add(new Organization(org, client));
                 }
 
                 orgs = await orgs.GetNextPage();

--- a/src/CloudFoundry.VisualStudio/Model/Organization.cs
+++ b/src/CloudFoundry.VisualStudio/Model/Organization.cs
@@ -13,14 +13,12 @@ namespace CloudFoundry.VisualStudio.Model
     {
         private readonly ListAllOrganizationsResponse _organization;
         private readonly CloudFoundryClient _client;
-        private readonly GetUserSummaryResponse _userSumary;
 
-        public Organization(ListAllOrganizationsResponse org, GetUserSummaryResponse userSummary, CloudFoundryClient client)
+        public Organization(ListAllOrganizationsResponse org, CloudFoundryClient client)
             : base(CloudItemType.Organization)
         {
             _client = client;
             _organization = org;
-            _userSumary = userSummary;
         }
 
         public override string Text
@@ -49,7 +47,7 @@ namespace CloudFoundry.VisualStudio.Model
             {
                 foreach (var space in spaces)
                 {
-                    result.Add(new Space(space, this._userSumary, this._client));
+                    result.Add(new Space(space, this._client));
                 }
 
                 spaces = await spaces.GetNextPage();
@@ -73,52 +71,5 @@ namespace CloudFoundry.VisualStudio.Model
         [Description("Date when the organization was created.")]
         public string CreationDate { get { return this._organization.EntityMetadata.CreatedAt; } }
 
-        [DisplayName("Organization roles")]
-        [Description("The roles of the user in the organization")]
-        public string OrgRoles
-        {
-            get
-            {
-                string orgRoles = string.Empty;
-
-
-                if (HasRole(_userSumary.Organizations, this._organization.EntityMetadata.Guid.ToString()))
-                {
-                    orgRoles = string.Format(CultureInfo.InvariantCulture, "Member, {0}", orgRoles);
-                }
-
-                if (HasRole(_userSumary.AuditedOrganizations, this._organization.EntityMetadata.Guid.ToString()))
-                {
-                    orgRoles = string.Format(CultureInfo.InvariantCulture, "Auditor, {0}", orgRoles);
-                }
-
-                if (HasRole(_userSumary.BillingManagedOrganizations, this._organization.EntityMetadata.Guid.ToString()))
-                {
-                    orgRoles = string.Format(CultureInfo.InvariantCulture, "Billing Manager, {0}", orgRoles);
-                }
-
-                if (HasRole(_userSumary.ManagedOrganizations, this._organization.EntityMetadata.Guid.ToString()))
-                {
-                    orgRoles = string.Format(CultureInfo.InvariantCulture, "Manager, {0}", orgRoles);
-                }
-
-                return orgRoles.Trim().TrimEnd(',');
-            }
-        }
-
-        internal static bool HasRole(Dictionary<string, dynamic>[] orgRoles, string id)
-        {
-            bool exist = false;
-
-            foreach (var org in orgRoles)
-            {
-                if (org["metadata"]["guid"].ToString() == id)
-                {
-                    return true;
-                }
-            }
-
-            return exist;
-        }
     }
 }

--- a/src/CloudFoundry.VisualStudio/Model/Space.cs
+++ b/src/CloudFoundry.VisualStudio/Model/Space.cs
@@ -12,14 +12,12 @@ namespace CloudFoundry.VisualStudio.Model
     {
         private readonly ListAllSpacesForOrganizationResponse _space;
         private readonly CloudFoundryClient _client;
-        private readonly GetUserSummaryResponse _userSummary;
 
-        public Space(ListAllSpacesForOrganizationResponse space, GetUserSummaryResponse userSummary, CloudFoundryClient client)
+        public Space(ListAllSpacesForOrganizationResponse space, CloudFoundryClient client)
             : base(CloudItemType.Space)
         {
             _client = client;
             _space = space;
-            _userSummary = userSummary;
         }
 
         public override string Text
@@ -60,33 +58,6 @@ namespace CloudFoundry.VisualStudio.Model
 
         [Description("Name of the space.")]
         public string Name { get { return _space.Name; } }
-
-        [DisplayName("Space roles")]
-        [Description("The space roles for the current user.")]
-        public string SpaceRoles
-        {
-            get
-            {
-                string spaceRoles = string.Empty;
-
-                if (Organization.HasRole(_userSummary.Spaces, this._space.EntityMetadata.Guid.ToString()))
-                {
-                    spaceRoles = string.Format(CultureInfo.InvariantCulture, "Developer, {0}", spaceRoles);
-                }
-
-                if (Organization.HasRole(_userSummary.AuditedSpaces, this._space.EntityMetadata.Guid.ToString()))
-                {
-                    spaceRoles = string.Format(CultureInfo.InvariantCulture, "Auditor, {0}", spaceRoles);
-                }
-
-                if (Organization.HasRole(_userSummary.ManagedSpaces, this._space.EntityMetadata.Guid.ToString()))
-                {
-                    spaceRoles = string.Format(CultureInfo.InvariantCulture, "Manager, {0}", spaceRoles);
-                }
-
-                return spaceRoles.Trim().TrimEnd(',');
-            }
-        }
 
         [DisplayName("Creation date")]
         [Description("Date when the space was created.")]


### PR DESCRIPTION
Remove display of organization and space roles in Cloud Foundry Explorer, not compatible with cf deployments