### PR TITLE
delete service after it's bound app is deleted

### DIFF
--- a/src/CloudFoundry.VisualStudio/CloudFoundryExplorer.xaml
+++ b/src/CloudFoundry.VisualStudio/CloudFoundryExplorer.xaml
@@ -57,7 +57,7 @@
               DataContext="{Binding SelectedValue, ElementName=ExplorerTree}">
             <TreeView.ItemTemplate>
                 <HierarchicalDataTemplate DataType="{x:Type model:CloudItem}" ItemsSource="{Binding Children}">
-                    <StackPanel Orientation="Horizontal" Height="22">
+                    <StackPanel Orientation="Horizontal" Height="22" >
                         <Grid Width="16" Height="16" VerticalAlignment="Center" Margin="5,0,0,0">
                             <Image Source="{Binding Icon}" />
                             <Image Source="{StaticResource SynchronizeSmallImage}" 
@@ -81,13 +81,14 @@
                         <DataTrigger Binding="{Binding Actions, Converter={StaticResource IsNull}}" Value="False">
                             <Setter Property="ContextMenu">
                                 <Setter.Value>
-                                    <ContextMenu ItemsSource="{Binding Actions}" Name="pelerinul">
+                                    <ContextMenu ItemsSource="{Binding Actions}" >
                                         <ContextMenu.ItemContainerStyle>
                                             <Style TargetType="{x:Type MenuItem}" BasedOn="{StaticResource MenuItemEventStyle}">
                                                 <Setter Property="Tag" Value="{Binding}"/>
                                                 <Setter Property="Header" Value="{Binding Text}"/>
                                                 <Setter Property="Icon" Value="{Binding Icon}"/>
-
+                                                <Setter Property="IsEnabled" Value ="{Binding CloudItem.IsEnabled}"/>
+                                                
                                                 <Style.Triggers>
                                                     <DataTrigger Binding="{Binding Text}" Value="-">
                                                         <Setter Property="Template">

--- a/src/CloudFoundry.VisualStudio/Model/App.cs
+++ b/src/CloudFoundry.VisualStudio/Model/App.cs
@@ -23,48 +23,48 @@
         }
 
         [Description("The buildpack of the application.")]
-        public string Buildpack 
-        { 
-            get { return this.app.Buildpack; } 
+        public string Buildpack
+        {
+            get { return this.app.Buildpack; }
         }
 
         [DisplayName("Detected buildpack")]
-        [Description("The buildpack that was detected by the Cloud Constroller.")]
-        public string DetectedBuildpack 
-        { 
-            get { return this.app.DetectedBuildpack; } 
+        [Description("The buildpack that was detected by the Cloud Controller.")]
+        public string DetectedBuildpack
+        {
+            get { return this.app.DetectedBuildpack; }
         }
 
         [Description("Number of instances that the application has.")]
-        public int? Instances 
-        { 
-            get { return this.app.Instances; } 
+        public int? Instances
+        {
+            get { return this.app.Instances; }
         }
 
         [Description("Number of running instances.")]
-        public int? RunningInstances 
-        { 
-            get { return this.app.RunningInstances;  } 
+        public int? RunningInstances
+        {
+            get { return this.app.RunningInstances; }
         }
 
         [DisplayName("Maximum memory")]
         [Description("Maximum memory of the application.")]
-        public int? Memory 
-        { 
-            get { return this.app.Memory; } 
+        public int? Memory
+        {
+            get { return this.app.Memory; }
         }
 
         [Description("The name of the application.")]
-        public string Name 
-        { 
-            get { return this.app.Name; } 
+        public string Name
+        {
+            get { return this.app.Name; }
         }
 
         [DisplayName("Last package update")]
         [Description("Date when the application's package was last updated.")]
-        public string CreationDate 
-        { 
-            get { return this.app.PackageUpdatedAt; } 
+        public string CreationDate
+        {
+            get { return this.app.PackageUpdatedAt; }
         }
 
         public override string Text
@@ -188,22 +188,31 @@
 
         private async Task Delete()
         {
-            var answer = MessageBoxHelper.WarningQuestion(
-                string.Format(
-                CultureInfo.InvariantCulture,
-                "Are you sure you want to delete application '{0}'? By deleting this application, all it's service bindings will be deleted.",
-                this.app.Name));
-
-            if (answer == System.Windows.Forms.DialogResult.Yes)
+            try
             {
-                var serviceBindings = await this.client.Apps.ListAllServiceBindingsForApp(this.app.Guid);
+                this.EnableNodes(this.app.Guid, false);
 
-                foreach (var serviceBinding in serviceBindings)
+                var answer = MessageBoxHelper.WarningQuestion(
+                    string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Are you sure you want to delete application '{0}'? By deleting this application, all it's service bindings will be deleted.",
+                    this.app.Name));
+
+                if (answer == System.Windows.Forms.DialogResult.Yes)
                 {
-                    await this.client.ServiceBindings.DeleteServiceBinding(serviceBinding.EntityMetadata.Guid);
-                }
+                    var serviceBindings = await this.client.Apps.ListAllServiceBindingsForApp(this.app.Guid);
 
-                await this.client.Apps.DeleteApp(this.app.Guid);
+                    foreach (var serviceBinding in serviceBindings)
+                    {
+                        await this.client.ServiceBindings.DeleteServiceBinding(serviceBinding.EntityMetadata.Guid);
+                    }
+
+                    await this.client.Apps.DeleteApp(this.app.Guid);
+                }
+            }
+            finally
+            {
+                this.EnableNodes(this.app.Guid, true);
             }
         }
 

--- a/src/CloudFoundry.VisualStudio/Model/AppFile.cs
+++ b/src/CloudFoundry.VisualStudio/Model/AppFile.cs
@@ -9,7 +9,7 @@
     using System.Threading.Tasks;
     using CloudFoundry.CloudController.V2.Client;
     using CloudFoundry.CloudController.V2.Client.Data;
-    
+
     internal class AppFile : CloudItem
     {
         private readonly string fileName;
@@ -18,7 +18,8 @@
         private readonly GetAppSummaryResponse app;
         private readonly int instanceNumber;
 
-        public AppFile(string fileName, string filePath, int instanceNumber, GetAppSummaryResponse app, CloudFoundryClient client) : base(CloudItemType.AppFile)
+        public AppFile(string fileName, string filePath, int instanceNumber, GetAppSummaryResponse app, CloudFoundryClient client)
+            : base(CloudItemType.AppFile)
         {
             this.fileName = fileName;
             this.filePath = filePath;
@@ -38,34 +39,13 @@
         }
 
         protected override IEnumerable<CloudItemAction> MenuActions
-        {   
+        {
             get
-            {   
+            {
                 return new CloudItemAction[]
                 {
                     new CloudItemAction(this, "Download file", Resources.Synchronizing, this.DownloadFile),
                 };
-            }   
-        }
-
-        private async Task DownloadFile()
-        {
-            List<RetrieveFileResponse> file = await this.client.Files.RetrieveFile(this.app.Guid, this.instanceNumber, this.filePath);
-
-            if (file.Count == 1)
-            {
-                string content = file[0].FileContent;
-
-                string downloadPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), this.fileName);
-
-                System.IO.File.WriteAllText(downloadPath, content);
-
-                EnvDTE.DTE dte = (EnvDTE.DTE)CloudFoundryVisualStudioPackage.GetGlobalService(typeof(EnvDTE.DTE));
-                dte.ItemOperations.OpenFile(downloadPath);
-            }
-            else
-            {
-                throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, "Error retrieving file contents {0}", this.fileName));
             }
         }
 
@@ -74,7 +54,6 @@
             await this.DownloadFile();
             return await Task<CloudItem[]>.Run(() => { return new CloudItem[] { }; });
         }
-
 
         private static System.Drawing.Icon GetFileIcon(string name, bool getLargeIcon, bool linkOverlay)
         {
@@ -104,6 +83,27 @@
             NativeMethods.DestroyIcon(shfi.hIcon); // Cleanup
 
             return icon;
+        }
+
+        private async Task DownloadFile()
+        {
+            List<RetrieveFileResponse> file = await this.client.Files.RetrieveFile(this.app.Guid, this.instanceNumber, this.filePath);
+
+            if (file.Count == 1)
+            {
+                string content = file[0].FileContent;
+
+                string downloadPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), this.fileName);
+
+                System.IO.File.WriteAllText(downloadPath, content);
+
+                EnvDTE.DTE dte = (EnvDTE.DTE)CloudFoundryVisualStudioPackage.GetGlobalService(typeof(EnvDTE.DTE));
+                dte.ItemOperations.OpenFile(downloadPath);
+            }
+            else
+            {
+                throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, "Error retrieving file contents {0}", this.fileName));
+            }
         }
     }
 }

--- a/src/CloudFoundry.VisualStudio/Model/Route.cs
+++ b/src/CloudFoundry.VisualStudio/Model/Route.cs
@@ -75,7 +75,7 @@
                     new CloudItemAction(this, "Delete", Resources.Delete, this.Delete, CloudItemActionContinuation.RefreshParent)
                 };
             }
-        }     
+        }
 
         protected override async Task<IEnumerable<CloudItem>> UpdateChildren()
         {
@@ -87,15 +87,23 @@
 
         private async Task Delete()
         {
-            var answer = MessageBoxHelper.WarningQuestion(
-                string.Format(
-                CultureInfo.InvariantCulture,
-                "Are you sure you want to delete route '{0}'?",
-                this.route.Host));
-
-            if (answer == System.Windows.Forms.DialogResult.Yes)
+            try
             {
-                await this.client.Routes.DeleteRoute(this.route.EntityMetadata.Guid);
+                this.EnableNodes(this.route.EntityMetadata.Guid, false);
+                var answer = MessageBoxHelper.WarningQuestion(
+                    string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Are you sure you want to delete route '{0}'?",
+                    this.route.Host));
+
+                if (answer == System.Windows.Forms.DialogResult.Yes)
+                {
+                    await this.client.Routes.DeleteRoute(this.route.EntityMetadata.Guid);
+                }
+            }
+            finally
+            {
+                this.EnableNodes(this.route.EntityMetadata.Guid, true);
             }
         }
     }

--- a/src/CloudFoundry.VisualStudio/Model/ServicesCollection.cs
+++ b/src/CloudFoundry.VisualStudio/Model/ServicesCollection.cs
@@ -65,7 +65,7 @@
                     var servicePlan = await this.client.ServicePlans.RetrieveServicePlan(service.ServicePlanGuid);
                     var systemService = await this.client.Services.RetrieveService(servicePlan.ServiceGuid);
 
-                    result.Add(new Service(service, appsSummary, servicePlan, systemService, serviceBindings, this.client));
+                    result.Add(new Service(service, appsSummary, servicePlan, systemService, this.client));
                 }
 
                 services = await services.GetNextPage();


### PR DESCRIPTION
this PR contains a fix for:
- fix for not being able to delete service after it's bound app is deleted
- disable menu items while a delete operation is in progress for a linked node.